### PR TITLE
extension of the callToString method

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -123,7 +123,9 @@ var callToString = function (calls) {
         .reduce(function (previousValue, currentValue) {
         var _currentValue = typeof currentValue === 'string'
             ? currentValue
-            : JSON.stringify(currentValue);
+            : (currentValue === null || currentValue === void 0 ? void 0 : currentValue.message) !== undefined
+                ? currentValue.message
+                : JSON.stringify(currentValue);
         return previousValue + " " + _currentValue;
     }, '')
         .trim();

--- a/dist/index.js
+++ b/dist/index.js
@@ -123,9 +123,7 @@ var callToString = function (calls) {
         .reduce(function (previousValue, currentValue) {
         var _currentValue = typeof currentValue === 'string'
             ? currentValue
-            : (currentValue === null || currentValue === void 0 ? void 0 : currentValue.message) !== undefined
-                ? currentValue.message
-                : JSON.stringify(currentValue);
+            : (currentValue === null || currentValue === void 0 ? void 0 : currentValue.message) || JSON.stringify(currentValue);
         return previousValue + " " + _currentValue;
     }, '')
         .trim();

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,6 +130,8 @@ export const callToString = (calls: any[]): string =>
             const _currentValue =
                 typeof currentValue === 'string'
                     ? currentValue
+                    : currentValue.message !== undefined
+                    ? currentValue.message
                     : JSON.stringify(currentValue);
             return `${previousValue} ${_currentValue}`;
         }, '')

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,9 +130,7 @@ export const callToString = (calls: any[]): string =>
             const _currentValue =
                 typeof currentValue === 'string'
                     ? currentValue
-                    : currentValue.message !== undefined
-                    ? currentValue.message
-                    : JSON.stringify(currentValue);
+                    : currentValue?.message || JSON.stringify(currentValue);
             return `${previousValue} ${_currentValue}`;
         }, '')
         .trim();

--- a/test/unitTest.ts
+++ b/test/unitTest.ts
@@ -241,19 +241,24 @@ describe('isExcludeMessage()', () => {
 
 describe('callToString()', () => {
     it('when parse different types, callToString should return string', () => {
-        const call: any[] = [
-            'stringValue',
-            1,
-            { foo: 'bar' },
-            ['a', 1],
-            undefined,
-            null,
-        ];
+        try {
+            throw new Error('Test error');
+        } catch (error) {
+            const call: any[] = [
+                'stringValue',
+                1,
+                { foo: 'bar' },
+                error,
+                ['a', 1],
+                undefined,
+                null,
+            ];
 
-        const expected = callToString(call);
+            const expected = callToString(call);
 
-        chai.expect(expected).to.equals(
-            'stringValue 1 {"foo":"bar"} ["a",1] undefined null'
-        );
+            chai.expect(expected).to.equals(
+                'stringValue 1 {"foo":"bar"} Test error ["a",1] undefined null'
+            );
+        }
     });
 });


### PR DESCRIPTION
In my case angular web application throwing error 
``` javascript
    /** @internal */
    _checkAllValuesPresent(value) {
        this._forEachChild((control, name) => {
            if (value[name] === undefined) {
                throw new Error(`Must supply a value for form control with name: '${name}'.`);
            }
        });
    }
```
![image](https://user-images.githubusercontent.com/11705902/127314078-25ac8dad-1b65-4a15-b919-086948a20470.png)

'cypress-fail-on-console-error' was catch this exception but when i'm want to exclude it by config - it's was not excluded

my config
``` javascript
failOnConsoleError({
  excludeMessages: ['Must supply a value for form'],
});
```
![image](https://user-images.githubusercontent.com/11705902/127314126-9b997c3b-4b5c-46c9-8b30-80dc60f5c1f2.png)

It was happen because method `callToString` return wrong string for throwing error. It was `ERROR {}`
I'm trying to fixing this method adding more ternary handling to be able return correct string.
I also extended the unit test for `callToString`
