### PR TITLE
Update index.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ failOnConsoleError();
 <br/>
 
 ```js
-import failOnConsoleError, { consoleType } from 'cypress-fail-on-console-error';
+import failOnConsoleError, { consoleType, Config } from 'cypress-fail-on-console-error';
 
-const config = {
+const config: Config = {
     excludeMessages: ['foo', /^some bar-regex.*/],
     includeConsoleTypes: [
         consoleType.ERROR,

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,5 +167,5 @@ export const cypressLogger = (name: string, message: any) => {
     });
 };
 
-export { ConsoleType as consoleType } from './types/ConsoleType';
 export { Config } from './types/Config';
+export { ConsoleType as consoleType } from './types/ConsoleType';

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,4 +167,5 @@ export const cypressLogger = (name: string, message: any) => {
     });
 };
 
-export const consoleType = ConsoleType;
+export { ConsoleType as consoleType } from './types/ConsoleType';
+export { Config } from './types/Config';


### PR DESCRIPTION
Changing the `consoleType` export back to a standard named export (not sure why it's lowercase).

Adding a `Config` as a named export to avoid `import { Config } from 'cypress-fail-on-console-error/dist/types/Config'`