### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ failOnConsoleError();
 | Parameter             | Default               | <div style="width:300px">Description</div>    |
 |---                    |---                    |---                                            |
 | `consoleMessages`     | `[]` | Exclude console messages from throwing `AssertionError`. Types `RegExp` and `string` are accepted. Strings will be converted to regular expression. [RegExp.test()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test?retiredLocale=de) will be used for console message matching. Make sure to [escape special characters](https://javascript.info/regexp-escaping). When console message property `stacktrace` exists, then the whole stacktrace can be matched. |
-| `consoleTypes` | `['error']` | Define console types for observation. `error`, `warn`, `info`, `debug`, `trace , `table` are accepted values.
+| `consoleTypes` | `['error']` | Define console types for observation. `error`, `warn`, `info`, `debug`, `trace` , `table` are accepted values.
 | `debug`          | `false`               | Enable debug logs for `consoleMessage_configConsoleMessage_match` and `consoleMessage_excluded` to cypress runner                                     
 
 <br/>


### PR DESCRIPTION
Added missing back tick:

```
`trace => `trace`
```